### PR TITLE
OO 3.* and uv

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.0] - 2026-04-28
+
+### Changed
+
+- Bumped OpenOrchestrator to 3.*
+- Switched main.py bootstrap to uv
+
 ## [1.2.2] - 2026-03-03
 
 ### Fixed

--- a/main.py
+++ b/main.py
@@ -9,9 +9,6 @@ import sys
 script_directory = os.path.dirname(os.path.realpath(__file__))
 os.chdir(script_directory)
 
-subprocess.run("python -m venv .venv", check=True)
-subprocess.run(r'.venv\Scripts\pip install .', check=True)
-
-command_args = [r".venv\Scripts\python", "-m", "src"] + sys.argv[1:]
-
+subprocess.run("pip install --upgrade uv", check=True)
+command_args = ["uv", "run", "python", "-m", "robot_framework"] + sys.argv[1:]
 subprocess.run(command_args, check=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "src"
-version = "1.2.2"
+version = "1.3.0"
 authors = [
   { name="ITK Development", email="itk-rpa@mkb.aarhus.dk" },
 ]
@@ -16,7 +16,7 @@ classifiers = [
     "Operating System :: Microsoft :: Windows",
 ]
 dependencies = [
-    "OpenOrchestrator == 2.*",
+    "OpenOrchestrator == 3.*",
     "Pillow == 9.5.0",
     "ITK-dev-shared-components == 2.*",
     "itk_dev_event_log == 1.*"


### PR DESCRIPTION
Bump OpenOrchestrator dependency to 3.* and switch main.py to the uv-based bootstrap.